### PR TITLE
Add render: plain text to version area in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yml
@@ -15,6 +15,7 @@ body:
       label: Terraform CLI and Provider Versions
       description: What versions of Terraform CLI and the provider?
       placeholder: Output of `terraform version` from configuration directory
+      render: plain text
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
For consistency, both the bug template and the feature template should use `render: plain text` for the version prompt