### PR TITLE
Documentation updates

### DIFF
--- a/.docs-links.txt
+++ b/.docs-links.txt
@@ -1,0 +1,14 @@
+docs.bastionzero.com/docs/admin-guide/authentication/service-accounts-management
+docs.bastionzero.com/docs/admin-guide/authentication/sso-management
+docs.bastionzero.com/docs/admin-guide/authorization#creating-an-api-key
+docs.bastionzero.com/docs/admin-guide/authorization#just-in-time
+docs.bastionzero.com/docs/admin-guide/authorization#kubernetes
+docs.bastionzero.com/docs/admin-guide/authorization#policy-management
+docs.bastionzero.com/docs/admin-guide/authorization#proxy
+docs.bastionzero.com/docs/admin-guide/authorization#registration-api-keys
+docs.bastionzero.com/docs/admin-guide/authorization#session-recording
+docs.bastionzero.com/docs/admin-guide/authorization#target-access
+docs.bastionzero.com/docs/automation-and-integrations/slack
+docs.bastionzero.com/docs/deployment/installing-the-agent#autodiscovery
+docs.bastionzero.com/docs/deployment/installing-the-agent#dynamic-access-targets
+docs.bastionzero.com/docs/deployment/installing-the-agent#step-1-agent-installation

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Use `make generate` to generate the documentation.
 The provider docs are made up of three components: schema, non-schema, and
 examples.
 
-**Schema:** To update documentation related to the schema attributes of
+**Schema** To update documentation related to the schema attributes of
 resources and data sources, find the schema definition in the `bastionzero/`
 source code folder and modify the `Description` field accordingly.
 
@@ -102,6 +102,10 @@ Example (on macOS):
 ```sh
 cat docs/guides/ec2-bzero-deployment-guide.md | pbcopy
 ```
+
+See [`.docs-links.txt`](./docs-links.txt) for a list of links to
+https://docs.bastionzero.com as parsed from the provider docs. This file is
+automatically generated after running `make generate`.
 
 ### Using a development build
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Example (on macOS):
 cat docs/guides/ec2-bzero-deployment-guide.md | pbcopy
 ```
 
-See [`.docs-links.txt`](./docs-links.txt) for a list of links to
+See [`.docs-links.txt`](./.docs-links.txt) for a list of links to
 https://docs.bastionzero.com as parsed from the provider docs. This file is
 automatically generated after running `make generate`.
 

--- a/bastionzero/environment/environment.go
+++ b/bastionzero/environment/environment.go
@@ -104,7 +104,7 @@ func makeEnvironmentResourceSchema() map[string]schema.Attribute {
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
-			Description: "If true, this environment is the default environment. False otherwise.",
+			Description: "If `true`, this environment is the default environment; `false` otherwise.",
 		},
 		"name": schema.StringAttribute{
 			Required:    true,
@@ -142,7 +142,7 @@ func makeEnvironmentResourceSchema() map[string]schema.Attribute {
 		"offline_cleanup_timeout_hours": schema.Int64Attribute{
 			Optional:    true,
 			Computed:    true,
-			Description: "The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to 90 days).",
+			Description: "The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to `2160` hours [90 days]).",
 			// Default to 90 days like in webapp
 			Default: int64default.StaticInt64(DefaultOfflineCleanupTimeoutHours),
 			Validators: []validator.Int64{

--- a/bastionzero/policy/jit/jit.go
+++ b/bastionzero/policy/jit/jit.go
@@ -139,14 +139,14 @@ func makeJITPolicyResourceSchema() map[string]schema.Attribute {
 	attributes["auto_approved"] = schema.BoolAttribute{
 		Optional: true,
 		Computed: true,
-		Description: "If true, then the policies created by this JIT policy will be automatically approved. " +
-			"If false, then policies will only be created based on request and approval from reviewers (Defaults to false).",
+		Description: "If `true`, then the policies created by this JIT policy will be automatically approved. " +
+			"If `false`, then policies will only be created based on request and approval from reviewers (Defaults to `false`).",
 		Default: booldefault.StaticBool(false),
 	}
 	attributes["duration"] = schema.Int64Attribute{
 		Optional:    true,
 		Computed:    true,
-		Description: "The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to 1 hour).",
+		Description: "The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to `60` minutes).",
 		// Same default as the webapp
 		Default: int64default.StaticInt64(60),
 		Validators: []validator.Int64{

--- a/bastionzero/policy/sessionrecording/sessionrecording.go
+++ b/bastionzero/policy/sessionrecording/sessionrecording.go
@@ -57,7 +57,7 @@ func makeSessionRecordingPolicyResourceSchema() map[string]schema.Attribute {
 	attributes["record_input"] = schema.BoolAttribute{
 		Optional:    true,
 		Computed:    true,
-		Description: "If true, then in addition to session output, session input should be recorded. If false, then only session output should be recorded (Defaults to false).",
+		Description: "If `true`, then in addition to session output, session input should be recorded. If `false`, then only session output should be recorded (Defaults to `false`).",
 		// Don't allow null value to make it easier when parsing results back
 		// into TF
 		Default: booldefault.StaticBool(false),

--- a/bastionzero/serviceaccount/serviceaccount.go
+++ b/bastionzero/serviceaccount/serviceaccount.go
@@ -88,7 +88,7 @@ func makeServiceAccountDataSourceSchema(withRequiredID bool) map[string]schema.A
 		},
 		"is_admin": schema.BoolAttribute{
 			Computed:    true,
-			Description: "If true, the service account is an administrator. False otherwise.",
+			Description: "If `true`, the service account is an administrator; `false` otherwise.",
 		},
 		"time_created": schema.StringAttribute{
 			Computed:    true,
@@ -104,7 +104,7 @@ func makeServiceAccountDataSourceSchema(withRequiredID bool) map[string]schema.A
 		},
 		"enabled": schema.BoolAttribute{
 			Computed:    true,
-			Description: "If true, the service account is currently enabled. False otherwise.",
+			Description: "If `true`, the service account is currently enabled; `false` otherwise.",
 		},
 	}
 }

--- a/bastionzero/target/attributes.go
+++ b/bastionzero/target/attributes.go
@@ -109,11 +109,11 @@ func BaseTargetDataSourceAttributes(targetType targettype.TargetType, opts *Base
 		},
 		"last_agent_update": schema.StringAttribute{
 			Computed:    true,
-			Description: fmt.Sprintf("The time this target's backing agent last had a transition change in status %s. Null if there has not been a single transition change.", internal.PrettyRFC3339Timestamp()),
+			Description: fmt.Sprintf("The time this target's proxy agent last had a transition change in status %s. Null if there has not been a single transition change.", internal.PrettyRFC3339Timestamp()),
 		},
 		"agent_version": schema.StringAttribute{
 			Computed:    true,
-			Description: "The target's backing agent's version.",
+			Description: "The target's proxy agent's version.",
 		},
 		"region": schema.StringAttribute{
 			Computed:    true,
@@ -121,7 +121,7 @@ func BaseTargetDataSourceAttributes(targetType targettype.TargetType, opts *Base
 		},
 		"agent_public_key": schema.StringAttribute{
 			Computed:    true,
-			Description: "The target's backing agent's public key.",
+			Description: "The target's proxy agent's public key.",
 		},
 	}
 }
@@ -190,7 +190,7 @@ type ControlChannelSummaryModel struct {
 func ControlChannelSummaryAttribute() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Computed:    true,
-		Description: "Information about the target's backing agent's currently active control channel. Null if the target has no active control channel.",
+		Description: "Information about the target's proxy agent's currently active control channel. Null if the target has no active control channel.",
 		Attributes: map[string]schema.Attribute{
 			"control_channel_id": schema.StringAttribute{
 				Computed:    true,

--- a/bastionzero/target/attributes.go
+++ b/bastionzero/target/attributes.go
@@ -140,7 +140,7 @@ func BaseVirtualTargetDataSourceAttributes(targetType targettype.TargetType) map
 		"proxy_target_id": schema.StringAttribute{
 			Computed:            true,
 			Description:         "The target's proxy target's ID (ID of a Bzero or Cluster target).",
-			MarkdownDescription: "The target's proxy target's ID (ID of a [Bzero](#bzero_target) or [Cluster](#cluster_target) target).",
+			MarkdownDescription: "The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).",
 		},
 		"remote_host": schema.StringAttribute{
 			Computed:    true,

--- a/bastionzero/target/dbtarget/dbtarget.go
+++ b/bastionzero/target/dbtarget/dbtarget.go
@@ -61,7 +61,7 @@ func makeDbTargetDataSourceSchema(opts *target.BaseTargetDataSourceAttributeOpti
 	maps.Copy(dbTargetAttributes, target.BaseVirtualTargetDataSourceAttributes(targettype.Db))
 	dbTargetAttributes["is_split_cert"] = schema.BoolAttribute{
 		Computed:    true,
-		Description: "If true, this Db target has the split cert feature enabled. False otherwise.",
+		Description: "If `true`, this Db target has the split cert feature enabled; `false` otherwise.",
 	}
 	dbTargetAttributes["database_type"] = schema.StringAttribute{
 		Computed:    true,

--- a/bastionzero/user/user.go
+++ b/bastionzero/user/user.go
@@ -66,7 +66,7 @@ func makeUserDataSourceSchema(withRequiredID bool) map[string]schema.Attribute {
 		},
 		"is_admin": schema.BoolAttribute{
 			Computed:    true,
-			Description: "If true, the user is an administrator. False otherwise.",
+			Description: "If `true`, the user is an administrator; `false` otherwise.",
 		},
 		"time_created": schema.StringAttribute{
 			Computed:    true,

--- a/docs/data-sources/ad_bash.md
+++ b/docs/data-sources/ad_bash.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_ad_bash Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Autodiscovery Script"
 description: |-
   Get a bash script that can be used to install the latest production BastionZero agent (bzero https://github.com/bastionzero/bzero) on your targets.
 ---

--- a/docs/data-sources/bzero_target.md
+++ b/docs/data-sources/bzero_target.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_bzero_target Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get information about a specific Bzero target in your BastionZero organization.
   Specify exactly one of id or name. When specifying a name, an error is triggered if more than one Bzero target is found. This data source retries with exponential backoff (provide optional timeouts.read duration https://pkg.go.dev/time#ParseDuration to control how long to retry. Defaults to 15 minutes.) until the Bzero target is found. This is useful if there is a chance the target does not exist yet (e.g. the target is in the process of registering to BastionZero).

--- a/docs/data-sources/bzero_target.md
+++ b/docs/data-sources/bzero_target.md
@@ -49,11 +49,11 @@ data "bastionzero_bzero_target" "example" {
 
 ### Read-Only
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
-- `control_channel` (Attributes) Information about the target's backing agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--control_channel))
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
+- `control_channel` (Attributes) Information about the target's proxy agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--control_channel))
 - `environment_id` (String) The target's environment's ID.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `status` (String) The target's status (one of `NotActivated`, `Offline`, `Online`, `Terminated`, `Error`, or `Restarting`).
 - `type` (String) The target's type (constant value `Bzero`).

--- a/docs/data-sources/bzero_targets.md
+++ b/docs/data-sources/bzero_targets.md
@@ -9,9 +9,9 @@ description: |-
 
 Get a list of all Bzero targets in your BastionZero organization.
 
-Note: You can use the [`bastionzero_bzero_target`](bzero_target) data source to
-obtain metadata about a single Bzero target if you already know the `id` or
-`name`.
+-> **Note** You can use the [`bastionzero_bzero_target`](bzero_target) data
+source to obtain metadata about a single Bzero target if you already know the
+`id` or `name`.
 
 ## Example Usage
 
@@ -40,12 +40,12 @@ output "ubuntu_targets" {
 
 Read-Only:
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
-- `control_channel` (Attributes) Information about the target's backing agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--targets--control_channel))
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
+- `control_channel` (Attributes) Information about the target's proxy agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--targets--control_channel))
 - `environment_id` (String) The target's environment's ID.
 - `id` (String) The target's unique ID.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `name` (String) The target's name.
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `status` (String) The target's status (one of `NotActivated`, `Offline`, `Online`, `Terminated`, `Error`, or `Restarting`).

--- a/docs/data-sources/bzero_targets.md
+++ b/docs/data-sources/bzero_targets.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_bzero_targets Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get a list of all Bzero targets in your BastionZero organization.
 ---

--- a/docs/data-sources/cluster_target.md
+++ b/docs/data-sources/cluster_target.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_cluster_target Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get information about a specific Cluster target in your BastionZero organization.
   Specify exactly one of id or name. When specifying a name, an error is triggered if more than one Cluster target is found. This data source retries with exponential backoff (provide optional timeouts.read duration https://pkg.go.dev/time#ParseDuration to control how long to retry. Defaults to 15 minutes.) until the Cluster target is found. This is useful if there is a chance the target does not exist yet (e.g. the target is in the process of registering to BastionZero).

--- a/docs/data-sources/cluster_target.md
+++ b/docs/data-sources/cluster_target.md
@@ -49,11 +49,11 @@ data "bastionzero_cluster_target" "example" {
 
 ### Read-Only
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
-- `control_channel` (Attributes) Information about the target's backing agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--control_channel))
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
+- `control_channel` (Attributes) Information about the target's proxy agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--control_channel))
 - `environment_id` (String) The target's environment's ID.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `status` (String) The target's status (one of `NotActivated`, `Offline`, `Online`, `Terminated`, `Error`, or `Restarting`).
 - `type` (String) The target's type (constant value `Bzero`).

--- a/docs/data-sources/cluster_targets.md
+++ b/docs/data-sources/cluster_targets.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_cluster_targets Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get a list of all Cluster targets in your BastionZero organization.
 ---

--- a/docs/data-sources/cluster_targets.md
+++ b/docs/data-sources/cluster_targets.md
@@ -9,9 +9,9 @@ description: |-
 
 Get a list of all Cluster targets in your BastionZero organization.
 
-Note: You can use the [`bastionzero_cluster_target`](cluster_target) data source
-to obtain metadata about a single Cluster target if you already know the `id` or
-`name`.
+-> **Note** You can use the [`bastionzero_cluster_target`](cluster_target) data
+source to obtain metadata about a single Cluster target if you already know the
+`id` or `name`.
 
 ## Example Usage
 
@@ -40,12 +40,12 @@ output "valid_cluster_users" {
 
 Read-Only:
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
-- `control_channel` (Attributes) Information about the target's backing agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--targets--control_channel))
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
+- `control_channel` (Attributes) Information about the target's proxy agent's currently active control channel. Null if the target has no active control channel. (see [below for nested schema](#nestedatt--targets--control_channel))
 - `environment_id` (String) The target's environment's ID.
 - `id` (String) The target's unique ID.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `name` (String) The target's name.
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `status` (String) The target's status (one of `NotActivated`, `Offline`, `Online`, `Terminated`, `Error`, or `Restarting`).

--- a/docs/data-sources/dac_target.md
+++ b/docs/data-sources/dac_target.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_dac_target Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get information about a specific dynamic access configuration (DAC) target in your BastionZero organization.
 ---

--- a/docs/data-sources/dac_targets.md
+++ b/docs/data-sources/dac_targets.md
@@ -11,8 +11,8 @@ Get a list of all dynamic access configuration (DAC) targets in your BastionZero
 
 Dynamic access configurations configure the provisioning of dynamic access targets (DATs). Learn more about the use cases of DATs and how to configure a DAT provisioning server [here](https://docs.bastionzero.com/docs/deployment/installing-the-agent#dynamic-access-targets). 
 
-Note: You can use the [`bastionzero_dac_target`](dac_target) data source to
-obtain metadata about a single DAC target if you already know the `id`.
+-> **Note** You can use the [`bastionzero_dac_target`](dac_target) data source
+to obtain metadata about a single DAC target if you already know the `id`.
 
 ## Example Usage
 

--- a/docs/data-sources/dac_targets.md
+++ b/docs/data-sources/dac_targets.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_dac_targets Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get a list of all dynamic access configuration (DAC) targets in your BastionZero organization.
 ---

--- a/docs/data-sources/db_target.md
+++ b/docs/data-sources/db_target.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_db_target Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get information about a specific Db target in your BastionZero organization.
 ---
@@ -36,7 +36,7 @@ data "bastionzero_db_target" "example" {
 - `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
-- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](#bzero_target) or [Cluster](#cluster_target) target).
+- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `remote_host` (String) The target's hostname or IP address.
 - `remote_port` (Number) The port of the Db server accessible via the target.

--- a/docs/data-sources/db_target.md
+++ b/docs/data-sources/db_target.md
@@ -28,12 +28,12 @@ data "bastionzero_db_target" "example" {
 
 ### Read-Only
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
 - `database_type` (String) The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
 - `environment_id` (String) The target's environment's ID.
-- `is_split_cert` (Boolean) If true, this Db target has the split cert feature enabled. False otherwise.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `is_split_cert` (Boolean) If `true`, this Db target has the split cert feature enabled; `false` otherwise.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
 - `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).

--- a/docs/data-sources/db_targets.md
+++ b/docs/data-sources/db_targets.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_db_targets Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get a list of all Db targets in your BastionZero organization.
 ---
@@ -80,7 +80,7 @@ Read-Only:
 - `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
-- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](#bzero_target) or [Cluster](#cluster_target) target).
+- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `remote_host` (String) The target's hostname or IP address.
 - `remote_port` (Number) The port of the Db server accessible via the target.

--- a/docs/data-sources/db_targets.md
+++ b/docs/data-sources/db_targets.md
@@ -9,8 +9,8 @@ description: |-
 
 Get a list of all Db targets in your BastionZero organization.
 
-Note: You can use the [`bastionzero_db_target`](db_target) data source to obtain
-metadata about a single Db target if you already know the `id`.
+-> **Note** You can use the [`bastionzero_db_target`](db_target) data source to
+obtain metadata about a single Db target if you already know the `id`.
 
 ## Example Usage
 
@@ -44,13 +44,13 @@ output "db_target" {
 }
 ```
 
-### Group Db targets with same base proxy target
+### Group Db targets with same proxy target
 
 ```terraform
 data "bastionzero_db_targets" "example" {}
 
-# Group Db targets with same base proxy target
-output "db_targets_by_base" {
+# Group Db targets with same proxy target
+output "db_targets_by_proxy_target" {
   value = {
     for each in data.bastionzero_db_targets.example.targets
     : each.proxy_target_id => { id = each.id, name = each.name }...
@@ -71,13 +71,13 @@ output "db_targets_by_base" {
 
 Read-Only:
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
 - `database_type` (String) The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
 - `environment_id` (String) The target's environment's ID.
 - `id` (String) The target's unique ID.
-- `is_split_cert` (Boolean) If true, this Db target has the split cert feature enabled. False otherwise.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `is_split_cert` (Boolean) If `true`, this Db target has the split cert feature enabled; `false` otherwise.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
 - `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -37,9 +37,9 @@ output "example_env_targets" {
 ### Read-Only
 
 - `description` (String) The environment's description.
-- `is_default` (Boolean) If true, this environment is the default environment. False otherwise.
+- `is_default` (Boolean) If `true`, this environment is the default environment; `false` otherwise.
 - `name` (String) The environment's name.
-- `offline_cleanup_timeout_hours` (Number) The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to 90 days).
+- `offline_cleanup_timeout_hours` (Number) The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to `2160` hours [90 days]).
 - `organization_id` (String) The environment's organization's ID.
 - `targets` (Attributes Map) Map of targets that belong to this environment. The map is keyed by a target's unique ID. (see [below for nested schema](#nestedatt--targets))
 - `time_created` (String) The time this environment was created in BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_environment Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Environment"
 description: |-
   Get information on a BastionZero environment. An environment is a collection of targets.
 ---

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -12,8 +12,8 @@ Get a list of all environments in your BastionZero organization. An environment 
 This data source is useful if the environments in question are not managed by
 Terraform, or you need to utilize any of the environments' data.
 
-Note: You can use the [`bastionzero_environment`](environment) data source to
-obtain metadata about a single environment if you already know the `id`.
+-> **Note** You can use the [`bastionzero_environment`](environment) data source
+to obtain metadata about a single environment if you already know the `id`.
 
 ## Example Usage
 
@@ -62,9 +62,9 @@ Read-Only:
 
 - `description` (String) The environment's description.
 - `id` (String) The environment's unique ID.
-- `is_default` (Boolean) If true, this environment is the default environment. False otherwise.
+- `is_default` (Boolean) If `true`, this environment is the default environment; `false` otherwise.
 - `name` (String) The environment's name.
-- `offline_cleanup_timeout_hours` (Number) The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to 90 days).
+- `offline_cleanup_timeout_hours` (Number) The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to `2160` hours [90 days]).
 - `organization_id` (String) The environment's organization's ID.
 - `targets` (Attributes Map) Map of targets that belong to this environment. The map is keyed by a target's unique ID. (see [below for nested schema](#nestedatt--environments--targets))
 - `time_created` (String) The time this environment was created in BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_environments Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Environment"
 description: |-
   Get a list of all environments in your BastionZero organization. An environment is a collection of targets.
 ---

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_groups Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Group"
 description: |-
   Get a list of all groups in your BastionZero organization. A group is an Identity provider (IdP) group synced to BastionZero.
 ---

--- a/docs/data-sources/jit_policies.md
+++ b/docs/data-sources/jit_policies.md
@@ -12,8 +12,8 @@ Get a list of all JIT policies in your BastionZero organization. A JIT policy pr
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_jit_policy`](jit_policy) data source to
-obtain metadata about a single policy if you already know the `id`.
+-> **Note** You can use the [`bastionzero_jit_policy`](jit_policy) data source
+to obtain metadata about a single policy if you already know the `id`.
 
 ## Example Usage
 
@@ -66,10 +66,10 @@ output "policy" {
 
 Read-Only:
 
-- `auto_approved` (Boolean) If true, then the policies created by this JIT policy will be automatically approved. If false, then policies will only be created based on request and approval from reviewers (Defaults to false).
+- `auto_approved` (Boolean) If `true`, then the policies created by this JIT policy will be automatically approved. If `false`, then policies will only be created based on request and approval from reviewers (Defaults to `false`).
 - `child_policies` (Attributes Set) Set of policies that a JIT policy applies to. (see [below for nested schema](#nestedatt--policies--child_policies))
 - `description` (String) The policy's description.
-- `duration` (Number) The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to 1 hour).
+- `duration` (Number) The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to `60` minutes).
 - `groups` (Attributes Set) Set of Identity Provider (IdP) groups that this policy applies to. (see [below for nested schema](#nestedatt--policies--groups))
 - `id` (String) The policy's unique ID.
 - `name` (String) The policy's name.

--- a/docs/data-sources/jit_policies.md
+++ b/docs/data-sources/jit_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_jit_policies Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get a list of all JIT policies in your BastionZero organization. A JIT policy provides just in time access to targets.
 ---

--- a/docs/data-sources/jit_policy.md
+++ b/docs/data-sources/jit_policy.md
@@ -31,10 +31,10 @@ data "bastionzero_jit_policy" "example" {
 
 ### Read-Only
 
-- `auto_approved` (Boolean) If true, then the policies created by this JIT policy will be automatically approved. If false, then policies will only be created based on request and approval from reviewers (Defaults to false).
+- `auto_approved` (Boolean) If `true`, then the policies created by this JIT policy will be automatically approved. If `false`, then policies will only be created based on request and approval from reviewers (Defaults to `false`).
 - `child_policies` (Attributes Set) Set of policies that a JIT policy applies to. (see [below for nested schema](#nestedatt--child_policies))
 - `description` (String) The policy's description.
-- `duration` (Number) The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to 1 hour).
+- `duration` (Number) The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to `60` minutes).
 - `groups` (Attributes Set) Set of Identity Provider (IdP) groups that this policy applies to. (see [below for nested schema](#nestedatt--groups))
 - `name` (String) The policy's name.
 - `subjects` (Attributes Set) Set of subjects that this policy applies to. (see [below for nested schema](#nestedatt--subjects))

--- a/docs/data-sources/jit_policy.md
+++ b/docs/data-sources/jit_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_jit_policy Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get information on a BastionZero JIT policy. A JIT policy provides just in time access to targets.
 ---

--- a/docs/data-sources/kubernetes_policies.md
+++ b/docs/data-sources/kubernetes_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_kubernetes_policies Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get a list of all Kubernetes policies in your BastionZero organization. A Kubernetes policy provides access to Cluster targets.
 ---

--- a/docs/data-sources/kubernetes_policies.md
+++ b/docs/data-sources/kubernetes_policies.md
@@ -12,8 +12,9 @@ Get a list of all Kubernetes policies in your BastionZero organization. A Kubern
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_kubernetes_policy`](kubernetes_policy) data
-source to obtain metadata about a single policy if you already know the `id`.
+-> **Note** You can use the [`bastionzero_kubernetes_policy`](kubernetes_policy)
+data source to obtain metadata about a single policy if you already know the
+`id`.
 
 ## Example Usage
 

--- a/docs/data-sources/kubernetes_policy.md
+++ b/docs/data-sources/kubernetes_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_kubernetes_policy Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get information on a BastionZero Kubernetes policy. A Kubernetes policy provides access to Cluster targets.
 ---

--- a/docs/data-sources/proxy_policies.md
+++ b/docs/data-sources/proxy_policies.md
@@ -12,7 +12,7 @@ Get a list of all proxy policies in your BastionZero organization. A proxy polic
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_proxy_policy`](proxy_policy) data
+-> **Note** You can use the [`bastionzero_proxy_policy`](proxy_policy) data
 source to obtain metadata about a single policy if you already know the `id`.
 
 ## Example Usage

--- a/docs/data-sources/proxy_policies.md
+++ b/docs/data-sources/proxy_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_proxy_policies Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get a list of all proxy policies in your BastionZero organization. A proxy policy provides access to Db and Web targets.
 ---

--- a/docs/data-sources/proxy_policy.md
+++ b/docs/data-sources/proxy_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_proxy_policy Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get information on a BastionZero proxy policy. A proxy policy provides access to Db and Web targets.
 ---

--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_service_account Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Service Account"
 description: |-
   Get information on a service account in your BastionZero organization. A service account is a Google, Azure, or generic service account that integrates with BastionZero by sharing its JSON Web Key Set (JWKS) URL. The headless authentication closely follows the OpenID Connect (OIDC) protocol.
 ---

--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -37,9 +37,9 @@ output "example_env_targets" {
 
 - `created_by` (String) Unique identifier for the subject that created this service account.
 - `email` (String) The service account's email address.
-- `enabled` (Boolean) If true, the service account is currently enabled. False otherwise.
+- `enabled` (Boolean) If `true`, the service account is currently enabled; `false` otherwise.
 - `external_id` (String) The service account's unique per service provider identifier provided by the user during creation.
-- `is_admin` (Boolean) If true, the service account is an administrator. False otherwise.
+- `is_admin` (Boolean) If `true`, the service account is an administrator; `false` otherwise.
 - `jwks_url` (String) The service account's publicly available JWKS URL that provides the public key that can be used to verify the tokens signed by the private key of this service account.
 - `jwks_url_pattern` (String) A URL pattern that all service accounts of the same service account provider follow in their JWKS URL.
 - `last_login` (String) The time this service account last logged into BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if the service account has never logged in.

--- a/docs/data-sources/service_accounts.md
+++ b/docs/data-sources/service_accounts.md
@@ -13,8 +13,9 @@ See the [Service Accounts
 Management](https://docs.bastionzero.com/docs/admin-guide/authentication/service-accounts-management)
 guide to learn how to configure service accounts with BastionZero.
 
-Note: You can use the [`bastionzero_service_account`](service_account) data
-source to obtain metadata about a single service account if you already know the `id`.
+-> **Note** You can use the [`bastionzero_service_account`](service_account)
+data source to obtain metadata about a single service account if you already
+know the `id`.
 
 ## Example Usage
 
@@ -45,10 +46,10 @@ Read-Only:
 
 - `created_by` (String) Unique identifier for the subject that created this service account.
 - `email` (String) The service account's email address.
-- `enabled` (Boolean) If true, the service account is currently enabled. False otherwise.
+- `enabled` (Boolean) If `true`, the service account is currently enabled; `false` otherwise.
 - `external_id` (String) The service account's unique per service provider identifier provided by the user during creation.
 - `id` (String) The service account's unique ID.
-- `is_admin` (Boolean) If true, the service account is an administrator. False otherwise.
+- `is_admin` (Boolean) If `true`, the service account is an administrator; `false` otherwise.
 - `jwks_url` (String) The service account's publicly available JWKS URL that provides the public key that can be used to verify the tokens signed by the private key of this service account.
 - `jwks_url_pattern` (String) A URL pattern that all service accounts of the same service account provider follow in their JWKS URL.
 - `last_login` (String) The time this service account last logged into BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if the service account has never logged in.

--- a/docs/data-sources/service_accounts.md
+++ b/docs/data-sources/service_accounts.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_service_accounts Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Service Account"
 description: |-
   Get a list of all service accounts in your BastionZero organization. A service account is a Google, Azure, or generic service account that integrates with BastionZero by sharing its JSON Web Key Set (JWKS) URL. The headless authentication closely follows the OpenID Connect (OIDC) protocol.
 ---

--- a/docs/data-sources/sessionrecording_policies.md
+++ b/docs/data-sources/sessionrecording_policies.md
@@ -12,8 +12,9 @@ Get a list of all session recording policies in your BastionZero organization. A
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_sessionrecording_policy`](sessionrecording_policy) data
-source to obtain metadata about a single policy if you already know the `id`.
+-> **Note** You can use the
+[`bastionzero_sessionrecording_policy`](sessionrecording_policy) data source to
+obtain metadata about a single policy if you already know the `id`.
 
 ## Example Usage
 
@@ -61,7 +62,7 @@ Read-Only:
 - `groups` (Attributes Set) Set of Identity Provider (IdP) groups that this policy applies to. (see [below for nested schema](#nestedatt--policies--groups))
 - `id` (String) The policy's unique ID.
 - `name` (String) The policy's name.
-- `record_input` (Boolean) If true, then in addition to session output, session input should be recorded. If false, then only session output should be recorded (Defaults to false).
+- `record_input` (Boolean) If `true`, then in addition to session output, session input should be recorded. If `false`, then only session output should be recorded (Defaults to `false`).
 - `subjects` (Attributes Set) Set of subjects that this policy applies to. (see [below for nested schema](#nestedatt--policies--subjects))
 - `type` (String) The policy's type (constant value `SessionRecording`).
 

--- a/docs/data-sources/sessionrecording_policies.md
+++ b/docs/data-sources/sessionrecording_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_sessionrecording_policies Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get a list of all session recording policies in your BastionZero organization. A session recording policy governs whether users' I/O during shell connections are recorded.
 ---

--- a/docs/data-sources/sessionrecording_policy.md
+++ b/docs/data-sources/sessionrecording_policy.md
@@ -34,7 +34,7 @@ data "bastionzero_sessionrecording_policy" "example" {
 - `description` (String) The policy's description.
 - `groups` (Attributes Set) Set of Identity Provider (IdP) groups that this policy applies to. (see [below for nested schema](#nestedatt--groups))
 - `name` (String) The policy's name.
-- `record_input` (Boolean) If true, then in addition to session output, session input should be recorded. If false, then only session output should be recorded (Defaults to false).
+- `record_input` (Boolean) If `true`, then in addition to session output, session input should be recorded. If `false`, then only session output should be recorded (Defaults to `false`).
 - `subjects` (Attributes Set) Set of subjects that this policy applies to. (see [below for nested schema](#nestedatt--subjects))
 - `type` (String) The policy's type (constant value `SessionRecording`).
 

--- a/docs/data-sources/sessionrecording_policy.md
+++ b/docs/data-sources/sessionrecording_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_sessionrecording_policy Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get information on a BastionZero session recording policy. A session recording policy governs whether users' I/O during shell connections are recorded.
 ---

--- a/docs/data-sources/targetconnect_policies.md
+++ b/docs/data-sources/targetconnect_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_targetconnect_policies Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get a list of all target connect policies in your BastionZero organization. A target connect policy provides access to Bzero and DynamicAccessConfig targets.
 ---

--- a/docs/data-sources/targetconnect_policies.md
+++ b/docs/data-sources/targetconnect_policies.md
@@ -12,9 +12,9 @@ Get a list of all target connect policies in your BastionZero organization. A ta
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_targetconnect_policy`](targetconnect_policy)
-data source to obtain metadata about a single policy if you already know the
-`id`.
+-> **Note** You can use the
+[`bastionzero_targetconnect_policy`](targetconnect_policy) data source to obtain
+metadata about a single policy if you already know the `id`.
 
 ## Example Usage
 

--- a/docs/data-sources/targetconnect_policy.md
+++ b/docs/data-sources/targetconnect_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_targetconnect_policy Data Source - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Get information on a BastionZero target connect policy. A target connect policy provides access to Bzero and DynamicAccessConfig targets.
 ---

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_user Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "User"
 description: |-
   Get information on a user in your BastionZero organization.
 ---

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -34,7 +34,7 @@ data "bastionzero_user" "example_by_email" {
 
 - `email` (String) The user's email address.
 - `full_name` (String) The user's full name.
-- `is_admin` (Boolean) If true, the user is an administrator. False otherwise.
+- `is_admin` (Boolean) If `true`, the user is an administrator; `false` otherwise.
 - `last_login` (String) The time this user last logged into BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if the user has never logged in.
 - `organization_id` (String) The user's organization's ID.
 - `time_created` (String) The time this user was created in BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_users Data Source - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "User"
 description: |-
   Get a list of all users in your BastionZero organization.
 ---

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -9,8 +9,9 @@ description: |-
 
 Get a list of all users in your BastionZero organization.
 
-Note: You can use the [`bastionzero_user`](user) data source to obtain metadata
-about a single user if you already know the user's `id` or email address.
+-> **Note** You can use the [`bastionzero_user`](user) data source to obtain
+metadata about a single user if you already know the user's `id` or email
+address.
 
 ## Example Usage
 
@@ -50,7 +51,7 @@ Read-Only:
 - `email` (String) The user's email address.
 - `full_name` (String) The user's full name.
 - `id` (String) The user's unique ID.
-- `is_admin` (Boolean) If true, the user is an administrator. False otherwise.
+- `is_admin` (Boolean) If `true`, the user is an administrator; `false` otherwise.
 - `last_login` (String) The time this user last logged into BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if the user has never logged in.
 - `organization_id` (String) The user's organization's ID.
 - `time_created` (String) The time this user was created in BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.

--- a/docs/data-sources/web_target.md
+++ b/docs/data-sources/web_target.md
@@ -28,10 +28,10 @@ data "bastionzero_web_target" "example" {
 
 ### Read-Only
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
 - `environment_id` (String) The target's environment's ID.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Web daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
 - `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).

--- a/docs/data-sources/web_target.md
+++ b/docs/data-sources/web_target.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_web_target Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get information about a specific Web target in your BastionZero organization.
 ---
@@ -34,7 +34,7 @@ data "bastionzero_web_target" "example" {
 - `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Web daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
-- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](#bzero_target) or [Cluster](#cluster_target) target).
+- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `remote_host` (String) The target's hostname or IP address.
 - `remote_port` (Number) The port of the Web server accessible via the target.

--- a/docs/data-sources/web_targets.md
+++ b/docs/data-sources/web_targets.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_web_targets Data Source - terraform-provider-bastionzero"
-subcategory: "target"
+subcategory: "Target"
 description: |-
   Get a list of all Web targets in your BastionZero organization.
 ---
@@ -78,7 +78,7 @@ Read-Only:
 - `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Web daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
-- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](#bzero_target) or [Cluster](#cluster_target) target).
+- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).
 - `region` (String) The BastionZero region that this target has connected to (follows same naming convention as AWS regions).
 - `remote_host` (String) The target's hostname or IP address.
 - `remote_port` (Number) The port of the Web server accessible via the target.

--- a/docs/data-sources/web_targets.md
+++ b/docs/data-sources/web_targets.md
@@ -9,8 +9,8 @@ description: |-
 
 Get a list of all Web targets in your BastionZero organization.
 
-Note: You can use the [`bastionzero_web_target`](web_target) data source to
-obtain metadata about a single Web target if you already know the `id`.
+-> **Note** You can use the [`bastionzero_web_target`](web_target) data source
+to obtain metadata about a single Web target if you already know the `id`.
 
 ## Example Usage
 
@@ -44,13 +44,13 @@ output "web_target" {
 }
 ```
 
-### Group Web targets with same base proxy target
+### Group Web targets with same proxy target
 
 ```terraform
 data "bastionzero_web_targets" "example" {}
 
-# Group Web targets with same base proxy target
-output "web_targets_by_base" {
+# Group Web targets with same proxy target
+output "web_targets_by_proxy_target" {
   value = {
     for each in data.bastionzero_web_targets.example.targets
     : each.proxy_target_id => { id = each.id, name = each.name }...
@@ -71,11 +71,11 @@ output "web_targets_by_base" {
 
 Read-Only:
 
-- `agent_public_key` (String) The target's backing agent's public key.
-- `agent_version` (String) The target's backing agent's version.
+- `agent_public_key` (String) The target's proxy agent's public key.
+- `agent_version` (String) The target's proxy agent's version.
 - `environment_id` (String) The target's environment's ID.
 - `id` (String) The target's unique ID.
-- `last_agent_update` (String) The time this target's backing agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
+- `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Web daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.
 - `proxy_target_id` (String) The target's proxy target's ID (ID of a [Bzero](bzero_target) or [Cluster](cluster_target) target).

--- a/docs/guides/ec2-bzero-deployment-guide.md
+++ b/docs/guides/ec2-bzero-deployment-guide.md
@@ -32,14 +32,17 @@ in order to register the EC2 instance as a target in your BastionZero
 organization.
 * Use Terraform 1.x or higher.
 
+-> **Note** API keys and registration keys are reusable. There is no need to
+generate a new key if you already have one available.
+
 This guide assumes you have basic knowledge of the AWS Terraform provider as it
 is used to deploy an EC2 instance. Although this guide uses AWS to register a
-target, please note that BastionZero supports other cloud providers as well. Use
-this guide as a model to register your instances at other cloud providers.
+target, please note that BastionZero is cloud-agnostic. Use this guide as a
+model to register your instances at other cloud providers.
 
 ## Setup
 
-First, we setup the BastionZero Terraform provider and the [AWS Terraform
+First, we set up the BastionZero Terraform provider and the [AWS Terraform
 provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration).
 
 
@@ -305,22 +308,21 @@ zli connect ubuntu@instance-id
 
 Replace `instance-id` with the value of the `instance_id` output.
 
-### Setup a session recording policy
+### Set up a session recording policy
 
-Setup a session recording policy so that shell connections to your target are
+Set up a session recording policy so that shell connections to your target are
 recorded. Use the
 [`bastionzero_sessionrecording_policy`](../resources/sessionrecording_policy)
 resource to manage the policy in Terraform. Learn more about session recording
 policies
 [here](https://docs.bastionzero.com/docs/admin-guide/authorization#session-recording).
 
-### Setup a JIT policy
+### Set up a Just-in-Time (JIT) policy
 
 Enable the [Slack
 integration](https://docs.bastionzero.com/docs/automation-and-integrations/slack)
-in your BastionZero organization, so that you can write just-in-time (JIT)
-policies to grant temporary access to your BastionZero target subject to
-administrator approval.
+in your BastionZero organization, so that you can write JIT policies to grant
+temporary access to your BastionZero target subject to administrator approval.
 
 Use the [`bastionzero_jit_policy`](../resources/jit_policy) resource to manage
 the policy in Terraform. Learn more about JIT policies

--- a/docs/guides/eks-bzero-deployment-guide.md
+++ b/docs/guides/eks-bzero-deployment-guide.md
@@ -33,15 +33,18 @@ organization.
 * Use Terraform 1.x or higher.
 * You must have an EKS cluster that is already deployed and ready to use.
 
+-> **Note** API keys and registration keys are reusable. There is no need to
+generate a new key if you already have one available.
+
 This guide assumes you have basic knowledge of the AWS Terraform provider, Helm
 Terraform provider, and Kubernetes Terraform provider. All three providers are
 used to install the Bzero agent in your EKS cluster. Please note that
-BastionZero supports other cloud providers as well. Use this guide as a model to
-register your Kubernetes clusters at other cloud providers.
+BastionZero is cloud-agnostic. Use this guide as a model to register your
+Kubernetes clusters at other cloud providers.
 
 ## Setup
 
-First, we setup the BastionZero Terraform provider, the [AWS Terraform
+First, we set up the BastionZero Terraform provider, the [AWS Terraform
 provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration),
 the [Helm Terraform
 provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs#authentication),
@@ -368,13 +371,12 @@ kubectl get pods -A
 
 Replace `cluster-id` with your EKS cluster ID.
 
-### Setup a JIT policy
+### Set up a Just-in-Time (JIT) policy
 
 Enable the [Slack
 integration](https://docs.bastionzero.com/docs/automation-and-integrations/slack)
-in your BastionZero organization, so that you can write just-in-time (JIT)
-policies to grant temporary access to your BastionZero target subject to
-administrator approval.
+in your BastionZero organization, so that you can write JIT policies to grant
+temporary access to your BastionZero target subject to administrator approval.
 
 Use the [`bastionzero_jit_policy`](../resources/jit_policy) resource to manage
 the policy in Terraform. Learn more about JIT policies

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -9,6 +9,10 @@ description: |-
 
 Provides a BastionZero environment resource. An environment is a collection of targets.
 
+~> **Note on offline target cleanup** An environment's
+[`offline_cleanup_timeout_hours`](#offline_cleanup_timeout_hours) cannot exceed
+4320 hours (180 days).
+
 ## Example Usage
 
 Create an environment named `example-env`:
@@ -31,12 +35,12 @@ resource "bastionzero_environment" "example" {
 ### Optional
 
 - `description` (String) The environment's description.
-- `offline_cleanup_timeout_hours` (Number) The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to 90 days).
+- `offline_cleanup_timeout_hours` (Number) The amount of time (in hours) to wait until offline targets are automatically removed by BastionZero (Defaults to `2160` hours [90 days]).
 
 ### Read-Only
 
 - `id` (String) The environment's unique ID.
-- `is_default` (Boolean) If true, this environment is the default environment. False otherwise.
+- `is_default` (Boolean) If `true`, this environment is the default environment; `false` otherwise.
 - `organization_id` (String) The environment's organization's ID.
 - `targets` (Attributes Map) Map of targets that belong to this environment. The map is keyed by a target's unique ID. (see [below for nested schema](#nestedatt--targets))
 - `time_created` (String) The time this environment was created in BastionZero formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_environment Resource - terraform-provider-bastionzero"
-subcategory: ""
+subcategory: "Environment"
 description: |-
   Provides a BastionZero environment resource. An environment is a collection of targets.
 ---

--- a/docs/resources/jit_policy.md
+++ b/docs/resources/jit_policy.md
@@ -12,7 +12,7 @@ Provides a BastionZero just-in-time (JIT) policy. JIT policies provide temporary
 Learn more about JIT policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#just-in-time).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name.
-If the configured [`name`](#name) is not unique, an error is thrown.
+If the configured [`name`](#required) is not unique, an error is thrown.
 
 ~> **Note on child policies** A JIT policy's [`child_policies`](#child_policies)
 can only refer to policies of the following types:

--- a/docs/resources/jit_policy.md
+++ b/docs/resources/jit_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_jit_policy Resource - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Provides a BastionZero just-in-time (JIT) policy. JIT policies provide temporary access to any BastionZero target.
 ---

--- a/docs/resources/jit_policy.md
+++ b/docs/resources/jit_policy.md
@@ -125,9 +125,9 @@ resource "bastionzero_jit_policy" "example" {
 
 ### Optional
 
-- `auto_approved` (Boolean) If true, then the policies created by this JIT policy will be automatically approved. If false, then policies will only be created based on request and approval from reviewers (Defaults to false).
+- `auto_approved` (Boolean) If `true`, then the policies created by this JIT policy will be automatically approved. If `false`, then policies will only be created based on request and approval from reviewers (Defaults to `false`).
 - `description` (String) The policy's description.
-- `duration` (Number) The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to 1 hour).
+- `duration` (Number) The amount of time (in minutes) after which the access granted by this JIT policy will expire (Defaults to `60` minutes).
 - `groups` (Attributes Set) Set of Identity Provider (IdP) groups that this policy applies to. (see [below for nested schema](#nestedatt--groups))
 - `subjects` (Attributes Set) Set of subjects that this policy applies to. (see [below for nested schema](#nestedatt--subjects))
 

--- a/docs/resources/kubernetes_policy.md
+++ b/docs/resources/kubernetes_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_kubernetes_policy Resource - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Provides a BastionZero Kubernetes policy. Kubernetes policies provide access to Cluster targets.
 ---

--- a/docs/resources/kubernetes_policy.md
+++ b/docs/resources/kubernetes_policy.md
@@ -12,7 +12,7 @@ Provides a BastionZero Kubernetes policy. Kubernetes policies provide access to 
 Learn more about Kubernetes policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#kubernetes).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/docs/resources/proxy_policy.md
+++ b/docs/resources/proxy_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_proxy_policy Resource - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Provides a BastionZero proxy policy. Proxy policies provide access to Db and Web targets.
 ---

--- a/docs/resources/proxy_policy.md
+++ b/docs/resources/proxy_policy.md
@@ -12,7 +12,7 @@ Provides a BastionZero proxy policy. Proxy policies provide access to Db and Web
 Learn more about proxy policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#proxy).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/docs/resources/sessionrecording_policy.md
+++ b/docs/resources/sessionrecording_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_sessionrecording_policy Resource - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Provides a BastionZero session recording policy. Session recording policies govern whether users' I/O during shell connections are recorded.
 ---

--- a/docs/resources/sessionrecording_policy.md
+++ b/docs/resources/sessionrecording_policy.md
@@ -47,7 +47,7 @@ resource "bastionzero_sessionrecording_policy" "example" {
 
 - `description` (String) The policy's description.
 - `groups` (Attributes Set) Set of Identity Provider (IdP) groups that this policy applies to. (see [below for nested schema](#nestedatt--groups))
-- `record_input` (Boolean) If true, then in addition to session output, session input should be recorded. If false, then only session output should be recorded (Defaults to false).
+- `record_input` (Boolean) If `true`, then in addition to session output, session input should be recorded. If `false`, then only session output should be recorded (Defaults to `false`).
 - `subjects` (Attributes Set) Set of subjects that this policy applies to. (see [below for nested schema](#nestedatt--subjects))
 
 ### Read-Only

--- a/docs/resources/sessionrecording_policy.md
+++ b/docs/resources/sessionrecording_policy.md
@@ -12,7 +12,7 @@ Provides a BastionZero session recording policy. Session recording policies gove
 Learn more about session recording policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#session-recording).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/docs/resources/targetconnect_policy.md
+++ b/docs/resources/targetconnect_policy.md
@@ -12,7 +12,7 @@ Provides a BastionZero target connect policy. Target connect policies provide ac
 Learn more about target connect policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#target-access).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/docs/resources/targetconnect_policy.md
+++ b/docs/resources/targetconnect_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "bastionzero_targetconnect_policy Resource - terraform-provider-bastionzero"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
   Provides a BastionZero target connect policy. Target connect policies provide access to Bzero and DynamicAccessConfig targets.
 ---

--- a/examples/data-sources/bastionzero_db_targets/group-by.tf
+++ b/examples/data-sources/bastionzero_db_targets/group-by.tf
@@ -1,7 +1,7 @@
 data "bastionzero_db_targets" "example" {}
 
-# Group Db targets with same base proxy target
-output "db_targets_by_base" {
+# Group Db targets with same proxy target
+output "db_targets_by_proxy_target" {
   value = {
     for each in data.bastionzero_db_targets.example.targets
     : each.proxy_target_id => { id = each.id, name = each.name }...

--- a/examples/data-sources/bastionzero_web_targets/group-by.tf
+++ b/examples/data-sources/bastionzero_web_targets/group-by.tf
@@ -1,7 +1,7 @@
 data "bastionzero_web_targets" "example" {}
 
-# Group Web targets with same base proxy target
-output "web_targets_by_base" {
+# Group Web targets with same proxy target
+output "web_targets_by_proxy_target" {
   value = {
     for each in data.bastionzero_web_targets.example.targets
     : each.proxy_target_id => { id = each.id, name = each.name }...

--- a/main.go
+++ b/main.go
@@ -18,6 +18,9 @@ import (
 // Run the docs generation tool
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
+// Run the genlinks script to find links to the BastionZero docs website in the provider docs
+//go:generate bash scripts/genlinks.sh
+
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.

--- a/scripts/genlinks.sh
+++ b/scripts/genlinks.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Find all links to BastionZero docs website and paste in .docs-links.txt file
+echo "$(grep -h -r --only-matching 'docs.bastionzero.com[^) ]*' templates | sort --unique)" >| ./.docs-links.txt

--- a/templates/data-sources/ad_bash.md.tmpl
+++ b/templates/data-sources/ad_bash.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Autodiscovery Script"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/bzero_target.md.tmpl
+++ b/templates/data-sources/bzero_target.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/bzero_targets.md.tmpl
+++ b/templates/data-sources/bzero_targets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/bzero_targets.md.tmpl
+++ b/templates/data-sources/bzero_targets.md.tmpl
@@ -9,9 +9,9 @@ description: |-
 
 {{ .Description | trimspace }}
 
-Note: You can use the [`bastionzero_bzero_target`](bzero_target) data source to
-obtain metadata about a single Bzero target if you already know the `id` or
-`name`.
+-> **Note** You can use the [`bastionzero_bzero_target`](bzero_target) data
+source to obtain metadata about a single Bzero target if you already know the
+`id` or `name`.
 
 ## Example Usage
 

--- a/templates/data-sources/cluster_target.md.tmpl
+++ b/templates/data-sources/cluster_target.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/cluster_targets.md.tmpl
+++ b/templates/data-sources/cluster_targets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/cluster_targets.md.tmpl
+++ b/templates/data-sources/cluster_targets.md.tmpl
@@ -9,9 +9,9 @@ description: |-
 
 {{ .Description | trimspace }}
 
-Note: You can use the [`bastionzero_cluster_target`](cluster_target) data source
-to obtain metadata about a single Cluster target if you already know the `id` or
-`name`.
+-> **Note** You can use the [`bastionzero_cluster_target`](cluster_target) data
+source to obtain metadata about a single Cluster target if you already know the
+`id` or `name`.
 
 ## Example Usage
 

--- a/templates/data-sources/dac_target.md.tmpl
+++ b/templates/data-sources/dac_target.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/dac_targets.md.tmpl
+++ b/templates/data-sources/dac_targets.md.tmpl
@@ -11,8 +11,8 @@ description: |-
 
 Dynamic access configurations configure the provisioning of dynamic access targets (DATs). Learn more about the use cases of DATs and how to configure a DAT provisioning server [here](https://docs.bastionzero.com/docs/deployment/installing-the-agent#dynamic-access-targets). 
 
-Note: You can use the [`bastionzero_dac_target`](dac_target) data source to
-obtain metadata about a single DAC target if you already know the `id`.
+-> **Note** You can use the [`bastionzero_dac_target`](dac_target) data source
+to obtain metadata about a single DAC target if you already know the `id`.
 
 ## Example Usage
 

--- a/templates/data-sources/dac_targets.md.tmpl
+++ b/templates/data-sources/dac_targets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/db_target.md.tmpl
+++ b/templates/data-sources/db_target.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/db_targets.md.tmpl
+++ b/templates/data-sources/db_targets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/db_targets.md.tmpl
+++ b/templates/data-sources/db_targets.md.tmpl
@@ -9,8 +9,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
-Note: You can use the [`bastionzero_db_target`](db_target) data source to obtain
-metadata about a single Db target if you already know the `id`.
+-> **Note** You can use the [`bastionzero_db_target`](db_target) data source to
+obtain metadata about a single Db target if you already know the `id`.
 
 ## Example Usage
 
@@ -22,7 +22,7 @@ metadata about a single Db target if you already know the `id`.
 
 {{ tffile "examples/data-sources/bastionzero_db_targets/find-with-name.tf" }}
 
-### Group Db targets with same base proxy target
+### Group Db targets with same proxy target
 
 {{ tffile "examples/data-sources/bastionzero_db_targets/group-by.tf" }}
 

--- a/templates/data-sources/environment.md.tmpl
+++ b/templates/data-sources/environment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Environment"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/environments.md.tmpl
+++ b/templates/data-sources/environments.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Environment"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/environments.md.tmpl
+++ b/templates/data-sources/environments.md.tmpl
@@ -12,8 +12,8 @@ description: |-
 This data source is useful if the environments in question are not managed by
 Terraform, or you need to utilize any of the environments' data.
 
-Note: You can use the [`bastionzero_environment`](environment) data source to
-obtain metadata about a single environment if you already know the `id`.
+-> **Note** You can use the [`bastionzero_environment`](environment) data source
+to obtain metadata about a single environment if you already know the `id`.
 
 ## Example Usage
 

--- a/templates/data-sources/groups.md.tmpl
+++ b/templates/data-sources/groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Group"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/jit_policies.md.tmpl
+++ b/templates/data-sources/jit_policies.md.tmpl
@@ -12,8 +12,8 @@ description: |-
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_jit_policy`](jit_policy) data source to
-obtain metadata about a single policy if you already know the `id`.
+-> **Note** You can use the [`bastionzero_jit_policy`](jit_policy) data source
+to obtain metadata about a single policy if you already know the `id`.
 
 ## Example Usage
 

--- a/templates/data-sources/jit_policies.md.tmpl
+++ b/templates/data-sources/jit_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/jit_policy.md.tmpl
+++ b/templates/data-sources/jit_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/kubernetes_policies.md.tmpl
+++ b/templates/data-sources/kubernetes_policies.md.tmpl
@@ -12,8 +12,9 @@ description: |-
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_kubernetes_policy`](kubernetes_policy) data
-source to obtain metadata about a single policy if you already know the `id`.
+-> **Note** You can use the [`bastionzero_kubernetes_policy`](kubernetes_policy)
+data source to obtain metadata about a single policy if you already know the
+`id`.
 
 ## Example Usage
 

--- a/templates/data-sources/kubernetes_policies.md.tmpl
+++ b/templates/data-sources/kubernetes_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/kubernetes_policy.md.tmpl
+++ b/templates/data-sources/kubernetes_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/proxy_policies.md.tmpl
+++ b/templates/data-sources/proxy_policies.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_proxy_policy`](proxy_policy) data
+-> **Note** You can use the [`bastionzero_proxy_policy`](proxy_policy) data
 source to obtain metadata about a single policy if you already know the `id`.
 
 ## Example Usage

--- a/templates/data-sources/proxy_policies.md.tmpl
+++ b/templates/data-sources/proxy_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/proxy_policy.md.tmpl
+++ b/templates/data-sources/proxy_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/service_account.md.tmpl
+++ b/templates/data-sources/service_account.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Service Account"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/service_accounts.md.tmpl
+++ b/templates/data-sources/service_accounts.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Service Account"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/service_accounts.md.tmpl
+++ b/templates/data-sources/service_accounts.md.tmpl
@@ -13,8 +13,9 @@ See the [Service Accounts
 Management](https://docs.bastionzero.com/docs/admin-guide/authentication/service-accounts-management)
 guide to learn how to configure service accounts with BastionZero.
 
-Note: You can use the [`bastionzero_service_account`](service_account) data
-source to obtain metadata about a single service account if you already know the `id`.
+-> **Note** You can use the [`bastionzero_service_account`](service_account)
+data source to obtain metadata about a single service account if you already
+know the `id`.
 
 ## Example Usage
 

--- a/templates/data-sources/sessionrecording_policies.md.tmpl
+++ b/templates/data-sources/sessionrecording_policies.md.tmpl
@@ -12,8 +12,9 @@ description: |-
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_sessionrecording_policy`](sessionrecording_policy) data
-source to obtain metadata about a single policy if you already know the `id`.
+-> **Note** You can use the
+[`bastionzero_sessionrecording_policy`](sessionrecording_policy) data source to
+obtain metadata about a single policy if you already know the `id`.
 
 ## Example Usage
 

--- a/templates/data-sources/sessionrecording_policies.md.tmpl
+++ b/templates/data-sources/sessionrecording_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/sessionrecording_policy.md.tmpl
+++ b/templates/data-sources/sessionrecording_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/targetconnect_policies.md.tmpl
+++ b/templates/data-sources/targetconnect_policies.md.tmpl
@@ -12,9 +12,9 @@ description: |-
 This data source is useful if the policies in question are not managed by
 Terraform, or you need to utilize any of the policies' data.
 
-Note: You can use the [`bastionzero_targetconnect_policy`](targetconnect_policy)
-data source to obtain metadata about a single policy if you already know the
-`id`.
+-> **Note** You can use the
+[`bastionzero_targetconnect_policy`](targetconnect_policy) data source to obtain
+metadata about a single policy if you already know the `id`.
 
 ## Example Usage
 

--- a/templates/data-sources/targetconnect_policies.md.tmpl
+++ b/templates/data-sources/targetconnect_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/targetconnect_policy.md.tmpl
+++ b/templates/data-sources/targetconnect_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/user.md.tmpl
+++ b/templates/data-sources/user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "User"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/users.md.tmpl
+++ b/templates/data-sources/users.md.tmpl
@@ -9,8 +9,9 @@ description: |-
 
 {{ .Description | trimspace }}
 
-Note: You can use the [`bastionzero_user`](user) data source to obtain metadata
-about a single user if you already know the user's `id` or email address.
+-> **Note** You can use the [`bastionzero_user`](user) data source to obtain
+metadata about a single user if you already know the user's `id` or email
+address.
 
 ## Example Usage
 

--- a/templates/data-sources/users.md.tmpl
+++ b/templates/data-sources/users.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "User"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/web_target.md.tmpl
+++ b/templates/data-sources/web_target.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/web_targets.md.tmpl
+++ b/templates/data-sources/web_targets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "target"
+subcategory: "Target"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/web_targets.md.tmpl
+++ b/templates/data-sources/web_targets.md.tmpl
@@ -9,8 +9,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
-Note: You can use the [`bastionzero_web_target`](web_target) data source to
-obtain metadata about a single Web target if you already know the `id`.
+-> **Note** You can use the [`bastionzero_web_target`](web_target) data source
+to obtain metadata about a single Web target if you already know the `id`.
 
 ## Example Usage
 
@@ -22,7 +22,7 @@ obtain metadata about a single Web target if you already know the `id`.
 
 {{ tffile "examples/data-sources/bastionzero_web_targets/find-with-name.tf" }}
 
-### Group Web targets with same base proxy target
+### Group Web targets with same proxy target
 
 {{ tffile "examples/data-sources/bastionzero_web_targets/group-by.tf" }}
 

--- a/templates/guides/ec2-bzero-deployment-guide.md.tmpl
+++ b/templates/guides/ec2-bzero-deployment-guide.md.tmpl
@@ -32,14 +32,17 @@ in order to register the EC2 instance as a target in your BastionZero
 organization.
 * Use Terraform 1.x or higher.
 
+-> **Note** API keys and registration keys are reusable. There is no need to
+generate a new key if you already have one available.
+
 This guide assumes you have basic knowledge of the AWS Terraform provider as it
 is used to deploy an EC2 instance. Although this guide uses AWS to register a
-target, please note that BastionZero supports other cloud providers as well. Use
-this guide as a model to register your instances at other cloud providers.
+target, please note that BastionZero is cloud-agnostic. Use this guide as a
+model to register your instances at other cloud providers.
 
 ## Setup
 
-First, we setup the BastionZero Terraform provider and the [AWS Terraform
+First, we set up the BastionZero Terraform provider and the [AWS Terraform
 provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration).
 
 
@@ -173,22 +176,21 @@ zli connect ubuntu@instance-id
 
 Replace `instance-id` with the value of the `instance_id` output.
 
-### Setup a session recording policy
+### Set up a session recording policy
 
-Setup a session recording policy so that shell connections to your target are
+Set up a session recording policy so that shell connections to your target are
 recorded. Use the
 [`bastionzero_sessionrecording_policy`](../resources/sessionrecording_policy)
 resource to manage the policy in Terraform. Learn more about session recording
 policies
 [here](https://docs.bastionzero.com/docs/admin-guide/authorization#session-recording).
 
-### Setup a JIT policy
+### Set up a Just-in-Time (JIT) policy
 
 Enable the [Slack
 integration](https://docs.bastionzero.com/docs/automation-and-integrations/slack)
-in your BastionZero organization, so that you can write just-in-time (JIT)
-policies to grant temporary access to your BastionZero target subject to
-administrator approval.
+in your BastionZero organization, so that you can write JIT policies to grant
+temporary access to your BastionZero target subject to administrator approval.
 
 Use the [`bastionzero_jit_policy`](../resources/jit_policy) resource to manage
 the policy in Terraform. Learn more about JIT policies

--- a/templates/guides/eks-bzero-deployment-guide.md.tmpl
+++ b/templates/guides/eks-bzero-deployment-guide.md.tmpl
@@ -33,15 +33,18 @@ organization.
 * Use Terraform 1.x or higher.
 * You must have an EKS cluster that is already deployed and ready to use.
 
+-> **Note** API keys and registration keys are reusable. There is no need to
+generate a new key if you already have one available.
+
 This guide assumes you have basic knowledge of the AWS Terraform provider, Helm
 Terraform provider, and Kubernetes Terraform provider. All three providers are
 used to install the Bzero agent in your EKS cluster. Please note that
-BastionZero supports other cloud providers as well. Use this guide as a model to
-register your Kubernetes clusters at other cloud providers.
+BastionZero is cloud-agnostic. Use this guide as a model to register your
+Kubernetes clusters at other cloud providers.
 
 ## Setup
 
-First, we setup the BastionZero Terraform provider, the [AWS Terraform
+First, we set up the BastionZero Terraform provider, the [AWS Terraform
 provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration),
 the [Helm Terraform
 provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs#authentication),
@@ -182,13 +185,12 @@ kubectl get pods -A
 
 Replace `cluster-id` with your EKS cluster ID.
 
-### Setup a JIT policy
+### Set up a Just-in-Time (JIT) policy
 
 Enable the [Slack
 integration](https://docs.bastionzero.com/docs/automation-and-integrations/slack)
-in your BastionZero organization, so that you can write just-in-time (JIT)
-policies to grant temporary access to your BastionZero target subject to
-administrator approval.
+in your BastionZero organization, so that you can write JIT policies to grant
+temporary access to your BastionZero target subject to administrator approval.
 
 Use the [`bastionzero_jit_policy`](../resources/jit_policy) resource to manage
 the policy in Terraform. Learn more about JIT policies

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Environment"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -9,6 +9,10 @@ description: |-
 
 {{ .Description | trimspace }}
 
+~> **Note on offline target cleanup** An environment's
+[`offline_cleanup_timeout_hours`](#offline_cleanup_timeout_hours) cannot exceed
+4320 hours (180 days).
+
 ## Example Usage
 
 Create an environment named `example-env`:

--- a/templates/resources/jit_policy.md.tmpl
+++ b/templates/resources/jit_policy.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 Learn more about JIT policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#just-in-time).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name.
-If the configured [`name`](#name) is not unique, an error is thrown.
+If the configured [`name`](#required) is not unique, an error is thrown.
 
 ~> **Note on child policies** A JIT policy's [`child_policies`](#child_policies)
 can only refer to policies of the following types:

--- a/templates/resources/jit_policy.md.tmpl
+++ b/templates/resources/jit_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/kubernetes_policy.md.tmpl
+++ b/templates/resources/kubernetes_policy.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 Learn more about Kubernetes policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#kubernetes).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/templates/resources/kubernetes_policy.md.tmpl
+++ b/templates/resources/kubernetes_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/proxy_policy.md.tmpl
+++ b/templates/resources/proxy_policy.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 Learn more about proxy policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#proxy).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/templates/resources/proxy_policy.md.tmpl
+++ b/templates/resources/proxy_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/sessionrecording_policy.md.tmpl
+++ b/templates/resources/sessionrecording_policy.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 Learn more about session recording policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#session-recording).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 

--- a/templates/resources/sessionrecording_policy.md.tmpl
+++ b/templates/resources/sessionrecording_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/targetconnect_policy.md.tmpl
+++ b/templates/resources/targetconnect_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "policy"
+subcategory: "Policy"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/targetconnect_policy.md.tmpl
+++ b/templates/resources/targetconnect_policy.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 Learn more about target connect policies [here](https://docs.bastionzero.com/docs/admin-guide/authorization#target-access).
 
 ~> **Note on policy name** All policies (of any type) must have a unique name. If the
-configured [`name`](#name) is not unique, an error is thrown.
+configured [`name`](#required) is not unique, an error is thrown.
 
 ## Example Usage
 


### PR DESCRIPTION
+ Fixes some broken links in the documentation
+ Adds subcategories to every data source and resource
+ Capitalize all subcategories
+ Cleanup various things in the docs. Highlight more things, change wording, etc.
+ Create `.docs-links.txt` that is automatically generated when running `make generate`. It contains list of links to BastionZero docs (docs.bastionzero.com) that were referenced in the provider docs

You can preview the documentation by copying the raw markdown (found in `docs/`) to your clipboard and pasting it [here](https://registry.terraform.io/tools/doc-preview).

Example (on macOS):

```sh
cat docs/guides/ec2-bzero-deployment-guide.md | pbcopy
```