### PR TITLE
Fix test assertion that resource is truly gone from BastionZero

### DIFF
--- a/bastionzero/policy/jit/resource_jitpolicy_test.go
+++ b/bastionzero/policy/jit/resource_jitpolicy_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
-	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/apierror"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/policytype"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/subjecttype"
@@ -729,17 +728,10 @@ func testAccCheckResourceJITPolicyComputedAttr(resourceName string) resource.Tes
 }
 
 func testAccCheckJITPolicyDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "bastionzero_jit_policy" {
-			continue
-		}
-
-		// Try to find the policy
-		_, _, err := acctest.APIClient.Policies.GetJITPolicy(context.Background(), rs.Primary.ID)
-		if err != nil && !apierror.IsAPIErrorStatusCode(err, http.StatusNotFound) {
-			return fmt.Errorf("Error waiting for JIT policy (%s) to be destroyed: %s", rs.Primary.ID, err)
-		}
-	}
-
-	return nil
+	return acctest.CheckAllResourcesWithTypeDestroyed(
+		"bastionzero_jit_policy",
+		func(client *bastionzero.Client, ctx context.Context, id string) (*policies.JITPolicy, *http.Response, error) {
+			return client.Policies.GetJITPolicy(ctx, id)
+		},
+	)(s)
 }

--- a/bastionzero/policy/kubernetes/resource_kubernetespolicy_test.go
+++ b/bastionzero/policy/kubernetes/resource_kubernetespolicy_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
-	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/apierror"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/policytype"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/subjecttype"
@@ -820,17 +819,10 @@ func testAccCheckResourceKubernetesPolicyComputedAttr(resourceName string) resou
 }
 
 func testAccCheckKubernetesPolicyDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "bastionzero_kubernetes_policy" {
-			continue
-		}
-
-		// Try to find the policy
-		_, _, err := acctest.APIClient.Policies.GetKubernetesPolicy(context.Background(), rs.Primary.ID)
-		if err != nil && !apierror.IsAPIErrorStatusCode(err, http.StatusNotFound) {
-			return fmt.Errorf("Error waiting for Kubernetes policy (%s) to be destroyed: %s", rs.Primary.ID, err)
-		}
-	}
-
-	return nil
+	return acctest.CheckAllResourcesWithTypeDestroyed(
+		"bastionzero_kubernetes_policy",
+		func(client *bastionzero.Client, ctx context.Context, id string) (*policies.KubernetesPolicy, *http.Response, error) {
+			return client.Policies.GetKubernetesPolicy(ctx, id)
+		},
+	)(s)
 }

--- a/bastionzero/policy/proxy/resource_proxypolicy_test.go
+++ b/bastionzero/policy/proxy/resource_proxypolicy_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
-	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/apierror"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/policytype"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/subjecttype"
@@ -746,17 +745,10 @@ func testAccCheckResourceProxyPolicyComputedAttr(resourceName string) resource.T
 }
 
 func testAccCheckProxyPolicyDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "bastionzero_proxy_policy" {
-			continue
-		}
-
-		// Try to find the policy
-		_, _, err := acctest.APIClient.Policies.GetProxyPolicy(context.Background(), rs.Primary.ID)
-		if err != nil && !apierror.IsAPIErrorStatusCode(err, http.StatusNotFound) {
-			return fmt.Errorf("Error waiting for proxy policy (%s) to be destroyed: %s", rs.Primary.ID, err)
-		}
-	}
-
-	return nil
+	return acctest.CheckAllResourcesWithTypeDestroyed(
+		"bastionzero_proxy_policy",
+		func(client *bastionzero.Client, ctx context.Context, id string) (*policies.ProxyPolicy, *http.Response, error) {
+			return client.Policies.GetProxyPolicy(ctx, id)
+		},
+	)(s)
 }

--- a/bastionzero/policy/sessionrecording/resource_sessionrecordingpolicy_test.go
+++ b/bastionzero/policy/sessionrecording/resource_sessionrecordingpolicy_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
-	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/apierror"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/policytype"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/subjecttype"
@@ -507,17 +506,10 @@ func testAccCheckResourceSessionRecordingPolicyComputedAttr(resourceName string)
 }
 
 func testAccCheckSessionRecordingPolicyDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "bastionzero_sessionrecording_policy" {
-			continue
-		}
-
-		// Try to find the policy
-		_, _, err := acctest.APIClient.Policies.GetSessionRecordingPolicy(context.Background(), rs.Primary.ID)
-		if err != nil && !apierror.IsAPIErrorStatusCode(err, http.StatusNotFound) {
-			return fmt.Errorf("Error waiting for session recording policy (%s) to be destroyed: %s", rs.Primary.ID, err)
-		}
-	}
-
-	return nil
+	return acctest.CheckAllResourcesWithTypeDestroyed(
+		"bastionzero_sessionrecording_policy",
+		func(client *bastionzero.Client, ctx context.Context, id string) (*policies.SessionRecordingPolicy, *http.Response, error) {
+			return client.Policies.GetSessionRecordingPolicy(ctx, id)
+		},
+	)(s)
 }

--- a/bastionzero/policy/targetconnect/resource_targetconnectpolicy_test.go
+++ b/bastionzero/policy/targetconnect/resource_targetconnectpolicy_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
-	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/apierror"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/policytype"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/verbtype"
@@ -840,17 +839,10 @@ func testAccCheckResourceTargetConnectPolicyComputedAttr(resourceName string) re
 }
 
 func testAccCheckTargetConnectPolicyDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "bastionzero_targetconnect_policy" {
-			continue
-		}
-
-		// Try to find the policy
-		_, _, err := acctest.APIClient.Policies.GetTargetConnectPolicy(context.Background(), rs.Primary.ID)
-		if err != nil && !apierror.IsAPIErrorStatusCode(err, http.StatusNotFound) {
-			return fmt.Errorf("Error waiting for target connect policy (%s) to be destroyed: %s", rs.Primary.ID, err)
-		}
-	}
-
-	return nil
+	return acctest.CheckAllResourcesWithTypeDestroyed(
+		"bastionzero_targetconnect_policy",
+		func(client *bastionzero.Client, ctx context.Context, id string) (*policies.TargetConnectPolicy, *http.Response, error) {
+			return client.Policies.GetTargetConnectPolicy(ctx, id)
+		},
+	)(s)
 }


### PR DESCRIPTION
I noticed the logic in the test assertion that checks the resource no longer exists at BastionZero (after running terraform destroy) is incorrect. This PR fixes the function and makes it generic, so we don't have to repeat the logic and/or make the same mistake again.