### PR TITLE
Changie syntax fix in changelog entry

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230823-124039.yaml
+++ b/.changes/unreleased/BUG FIXES-20230823-124039.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'resource/environment: Remove require replacement behavior when an environment's `name` changes since the BastionZero API permits editing an environment's name after creation'
+body: "resource/environment: Remove require replacement behavior when an environment's `name` changes since the BastionZero API permits editing an environment's name after creation"
 time: 2023-08-23T12:40:39.4761-04:00
 custom:
   Issues: "35"


### PR DESCRIPTION
Since `'` is used as an apostrophe for `environment's`, we need to use surrounding double quotes for `body` to not confuse `changie` changelog generation