### PR TITLE
Add DatabaseAuthenticationConfig and deprecate SplitCert and DatabaseType

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20231012-124039.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20231012-124039.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: "data-source/db_target, data-source/db_targets: Add `database_authentication_config` attribute which
+  contains information about the db target's database auth configuration"
+time: 2023-10-12T12:40:39.598015-04:00
+custom:
+  Issues: "58"

--- a/.changes/unreleased/NOTES-20231012-140004.yaml
+++ b/.changes/unreleased/NOTES-20231012-140004.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'data-source/db_target, data-source/db_targets: Deprecate `database_type` and
+  `is_split_cert` attributes; use `database_authentication_config.database` and `database_authentication_config.authentication_type == "SplitCert"` instead'
+time: 2023-10-12T14:00:04.860882-04:00
+custom:
+  Issues: "58"

--- a/bastionzero/target/attributes.go
+++ b/bastionzero/target/attributes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/targets"
+	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/targets/dbauthconfig"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/targets/targetstatus"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/targettype"
 	"github.com/bastionzero/terraform-provider-bastionzero/internal"
@@ -232,4 +233,47 @@ func FlattenControlChannelSummary(ctx context.Context, apiObject *targets.Contro
 			"end_time":           endTime,
 		})
 	}
+}
+
+type DatabaseAuthenticationConfig struct {
+	AuthenticationType   types.String `tfsdk:"authentication_type"`
+	CloudServiceProvider types.String `tfsdk:"cloud_service_provider"`
+	Database             types.String `tfsdk:"database"`
+	Label                types.String `tfsdk:"label"`
+}
+
+func DatabaseAuthenticationConfigAttribute() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Computed:    true,
+		Description: "Information about the db target's database authentication configuration.",
+		Attributes: map[string]schema.Attribute{
+			"authentication_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "The type of authentication used when connecting to the database.",
+			},
+			"cloud_service_provider": schema.StringAttribute{
+				Computed:    true,
+				Description: "Cloud service provider hosting the database. Only used for certain types of authentication, such as ServiceAccountInjection.",
+			},
+			"database": schema.StringAttribute{
+				Computed:    true,
+				Description: "The type of database running on the target.",
+			},
+			"label": schema.StringAttribute{
+				Computed:    true,
+				Description: "User-friendly label for this database authentication configuration.",
+			},
+		},
+	}
+}
+
+func FlattenDatabaseAuthenticationConfig(ctx context.Context, apiObject dbauthconfig.DatabaseAuthenticationConfig) types.Object {
+	attributeTypes, _ := internal.AttributeTypes[ControlChannelSummaryModel](ctx)
+
+	return types.ObjectValueMust(attributeTypes, map[string]attr.Value{
+		"authentication_type":    types.StringPointerValue(apiObject.AuthenticationType),
+		"cloud_service_provider": types.StringPointerValue(apiObject.CloudServiceProvider),
+		"database":               types.StringPointerValue(apiObject.Database),
+		"label":                  types.StringPointerValue(apiObject.Label),
+	})
 }

--- a/bastionzero/target/attributes.go
+++ b/bastionzero/target/attributes.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/targets"
-	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/targets/dbauthconfig"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/targets/targetstatus"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/targettype"
 	"github.com/bastionzero/terraform-provider-bastionzero/internal"
@@ -233,47 +232,4 @@ func FlattenControlChannelSummary(ctx context.Context, apiObject *targets.Contro
 			"end_time":           endTime,
 		})
 	}
-}
-
-type DatabaseAuthenticationConfig struct {
-	AuthenticationType   types.String `tfsdk:"authentication_type"`
-	CloudServiceProvider types.String `tfsdk:"cloud_service_provider"`
-	Database             types.String `tfsdk:"database"`
-	Label                types.String `tfsdk:"label"`
-}
-
-func DatabaseAuthenticationConfigAttribute() schema.Attribute {
-	return schema.SingleNestedAttribute{
-		Computed:    true,
-		Description: "Information about the db target's database authentication configuration.",
-		Attributes: map[string]schema.Attribute{
-			"authentication_type": schema.StringAttribute{
-				Computed:    true,
-				Description: "The type of authentication used when connecting to the database.",
-			},
-			"cloud_service_provider": schema.StringAttribute{
-				Computed:    true,
-				Description: "Cloud service provider hosting the database. Only used for certain types of authentication, such as ServiceAccountInjection.",
-			},
-			"database": schema.StringAttribute{
-				Computed:    true,
-				Description: "The type of database running on the target.",
-			},
-			"label": schema.StringAttribute{
-				Computed:    true,
-				Description: "User-friendly label for this database authentication configuration.",
-			},
-		},
-	}
-}
-
-func FlattenDatabaseAuthenticationConfig(ctx context.Context, apiObject dbauthconfig.DatabaseAuthenticationConfig) types.Object {
-	attributeTypes, _ := internal.AttributeTypes[ControlChannelSummaryModel](ctx)
-
-	return types.ObjectValueMust(attributeTypes, map[string]attr.Value{
-		"authentication_type":    types.StringPointerValue(apiObject.AuthenticationType),
-		"cloud_service_provider": types.StringPointerValue(apiObject.CloudServiceProvider),
-		"database":               types.StringPointerValue(apiObject.Database),
-		"label":                  types.StringPointerValue(apiObject.Label),
-	})
 }

--- a/bastionzero/target/dbtarget/datasource_dbtargets_test.go
+++ b/bastionzero/target/dbtarget/datasource_dbtargets_test.go
@@ -51,6 +51,27 @@ func getValuesCheckMap(dbTarget *targets.DatabaseTarget) map[string]string {
 		valuesCheckMap["database_type"] = ""
 	}
 
+	if dbTarget.DatabaseAuthenticationConfig.AuthenticationType != nil {
+		valuesCheckMap["database_authentication_config.authentication_type"] = *dbTarget.DatabaseAuthenticationConfig.AuthenticationType
+	} else {
+		valuesCheckMap["database_authentication_config.authentication_type"] = ""
+	}
+	if dbTarget.DatabaseAuthenticationConfig.CloudServiceProvider != nil {
+		valuesCheckMap["database_authentication_config.cloud_service_provider"] = *dbTarget.DatabaseAuthenticationConfig.CloudServiceProvider
+	} else {
+		valuesCheckMap["database_authentication_config.cloud_service_provider"] = ""
+	}
+	if dbTarget.DatabaseAuthenticationConfig.Database != nil {
+		valuesCheckMap["database_authentication_config.database"] = *dbTarget.DatabaseAuthenticationConfig.Database
+	} else {
+		valuesCheckMap["database_authentication_config.database"] = ""
+	}
+	if dbTarget.DatabaseAuthenticationConfig.Label != nil {
+		valuesCheckMap["database_authentication_config.label"] = *dbTarget.DatabaseAuthenticationConfig.Label
+	} else {
+		valuesCheckMap["database_authentication_config.label"] = ""
+	}
+
 	return valuesCheckMap
 }
 

--- a/bastionzero/target/dbtarget/dbtarget.go
+++ b/bastionzero/target/dbtarget/dbtarget.go
@@ -23,12 +23,13 @@ type dbTargetModel struct {
 	Region          types.String `tfsdk:"region"`
 	AgentPublicKey  types.String `tfsdk:"agent_public_key"`
 
-	ProxyTargetID types.String `tfsdk:"proxy_target_id"`
-	RemoteHost    types.String `tfsdk:"remote_host"`
-	RemotePort    types.Int64  `tfsdk:"remote_port"`
-	LocalPort     types.Int64  `tfsdk:"local_port"`
-	IsSplitCert   types.Bool   `tfsdk:"is_split_cert"`
-	DatabaseType  types.String `tfsdk:"database_type"`
+	ProxyTargetID                types.String `tfsdk:"proxy_target_id"`
+	RemoteHost                   types.String `tfsdk:"remote_host"`
+	RemotePort                   types.Int64  `tfsdk:"remote_port"`
+	LocalPort                    types.Int64  `tfsdk:"local_port"`
+	IsSplitCert                  types.Bool   `tfsdk:"is_split_cert"`
+	DatabaseType                 types.String `tfsdk:"database_type"`
+	DatabaseAuthenticationConfig types.Object `tfsdk:"database_authentication_config"`
 }
 
 func (t *dbTargetModel) SetID(value types.String)              { t.ID = value }
@@ -54,18 +55,21 @@ func setDbTargetAttributes(ctx context.Context, schema *dbTargetModel, dbTarget 
 
 	schema.IsSplitCert = types.BoolValue(dbTarget.IsSplitCert)
 	schema.DatabaseType = types.StringPointerValue(dbTarget.DatabaseType)
+	schema.DatabaseAuthenticationConfig = target.FlattenDatabaseAuthenticationConfig(ctx, dbTarget.DatabaseAuthenticationConfig)
 }
 
 func makeDbTargetDataSourceSchema(opts *target.BaseTargetDataSourceAttributeOptions) map[string]schema.Attribute {
 	dbTargetAttributes := target.BaseTargetDataSourceAttributes(targettype.Db, opts)
 	maps.Copy(dbTargetAttributes, target.BaseVirtualTargetDataSourceAttributes(targettype.Db))
 	dbTargetAttributes["is_split_cert"] = schema.BoolAttribute{
-		Computed:    true,
-		Description: "If `true`, this Db target has the split cert feature enabled; `false` otherwise.",
+		Computed:           true,
+		Description:        "Deprecated. If `true`, this Db target has the split cert feature enabled; `false` otherwise.",
+		DeprecationMessage: "Do not depend on this attribute. This attribute will be removed in the future.",
 	}
 	dbTargetAttributes["database_type"] = schema.StringAttribute{
-		Computed:    true,
-		Description: "The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).",
+		Computed:           true,
+		Description:        "Deprecated. The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).",
+		DeprecationMessage: "Do not depend on this attribute. This attribute will be removed in the future.",
 	}
 
 	return dbTargetAttributes

--- a/docs/data-sources/db_target.md
+++ b/docs/data-sources/db_target.md
@@ -30,6 +30,7 @@ data "bastionzero_db_target" "example" {
 
 - `agent_public_key` (String) The target's proxy agent's public key.
 - `agent_version` (String) The target's proxy agent's version.
+- `database_authentication_config` (Attributes) Information about the db target's database authentication configuration. (see [below for nested schema](#nestedatt--database_authentication_config))
 - `database_type` (String, Deprecated) Deprecated. The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
 - `environment_id` (String) The target's environment's ID.
 - `is_split_cert` (Boolean, Deprecated) Deprecated. If `true`, this Db target has the split cert feature enabled; `false` otherwise.
@@ -42,3 +43,13 @@ data "bastionzero_db_target" "example" {
 - `remote_port` (Number) The port of the Db server accessible via the target.
 - `status` (String) The target's status (one of `NotActivated`, `Offline`, `Online`, `Terminated`, `Error`, or `Restarting`).
 - `type` (String) The target's type (constant value `Db`).
+
+<a id="nestedatt--database_authentication_config"></a>
+### Nested Schema for `database_authentication_config`
+
+Read-Only:
+
+- `authentication_type` (String) The type of authentication used when connecting to the database.
+- `cloud_service_provider` (String) Cloud service provider hosting the database. Only used for certain types of authentication, such as `ServiceAccountInjection`.
+- `database` (String) The type of database running on the target.
+- `label` (String) User-friendly label for this database authentication configuration.

--- a/docs/data-sources/db_target.md
+++ b/docs/data-sources/db_target.md
@@ -30,9 +30,9 @@ data "bastionzero_db_target" "example" {
 
 - `agent_public_key` (String) The target's proxy agent's public key.
 - `agent_version` (String) The target's proxy agent's version.
-- `database_type` (String) The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
+- `database_type` (String, Deprecated) Deprecated. The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
 - `environment_id` (String) The target's environment's ID.
-- `is_split_cert` (Boolean) If `true`, this Db target has the split cert feature enabled; `false` otherwise.
+- `is_split_cert` (Boolean, Deprecated) Deprecated. If `true`, this Db target has the split cert feature enabled; `false` otherwise.
 - `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.

--- a/docs/data-sources/db_targets.md
+++ b/docs/data-sources/db_targets.md
@@ -73,10 +73,10 @@ Read-Only:
 
 - `agent_public_key` (String) The target's proxy agent's public key.
 - `agent_version` (String) The target's proxy agent's version.
-- `database_type` (String) The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
+- `database_type` (String, Deprecated) Deprecated. The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
 - `environment_id` (String) The target's environment's ID.
 - `id` (String) The target's unique ID.
-- `is_split_cert` (Boolean) If `true`, this Db target has the split cert feature enabled; `false` otherwise.
+- `is_split_cert` (Boolean, Deprecated) Deprecated. If `true`, this Db target has the split cert feature enabled; `false` otherwise.
 - `last_agent_update` (String) The time this target's proxy agent last had a transition change in status formatted as a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Null if there has not been a single transition change.
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. Null if not configured.
 - `name` (String) The target's name.

--- a/docs/data-sources/db_targets.md
+++ b/docs/data-sources/db_targets.md
@@ -73,6 +73,7 @@ Read-Only:
 
 - `agent_public_key` (String) The target's proxy agent's public key.
 - `agent_version` (String) The target's proxy agent's version.
+- `database_authentication_config` (Attributes) Information about the db target's database authentication configuration. (see [below for nested schema](#nestedatt--targets--database_authentication_config))
 - `database_type` (String, Deprecated) Deprecated. The database's type. Can be null if this Db target does not have the split cert feature enabled (see `is_split_cert`).
 - `environment_id` (String) The target's environment's ID.
 - `id` (String) The target's unique ID.
@@ -86,3 +87,13 @@ Read-Only:
 - `remote_port` (Number) The port of the Db server accessible via the target.
 - `status` (String) The target's status (one of `NotActivated`, `Offline`, `Online`, `Terminated`, `Error`, or `Restarting`).
 - `type` (String) The target's type (constant value `Db`).
+
+<a id="nestedatt--targets--database_authentication_config"></a>
+### Nested Schema for `targets.database_authentication_config`
+
+Read-Only:
+
+- `authentication_type` (String) The type of authentication used when connecting to the database.
+- `cloud_service_provider` (String) Cloud service provider hosting the database. Only used for certain types of authentication, such as `ServiceAccountInjection`.
+- `database` (String) The type of database running on the target.
+- `label` (String) User-friendly label for this database authentication configuration.


### PR DESCRIPTION
BastionZero's REST API's returned object for database targets now has a `DatabaseAuthenticationConfig`, and that new field has replaced the individual `SplitCert` and `DatabaseType` fields.

This requires the following in the Terraform provider:
- Define `DatabaseAuthenticationConfigModel` 
- Add  `DatabaseAuthenticationConfigModel` to the database target model
- Deprecate `is_split_cert` and `database_type` 