### PR TITLE
Fix links to data sources in `bastionzero_db_target` resource docs

### DIFF
--- a/.changes/unreleased/NOTES-20240326-161540.yaml
+++ b/.changes/unreleased/NOTES-20240326-161540.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: Update `bastionzero_db_target` resource documentation
+time: 2024-03-26T16:15:40.830302-04:00
+custom:
+  Issues: "72"

--- a/bastionzero/target/dbtarget/dbtarget.go
+++ b/bastionzero/target/dbtarget/dbtarget.go
@@ -227,7 +227,7 @@ func makeDbTargetResourceSchema(ctx context.Context) map[string]resource_schema.
 		"proxy_target_id": resource_schema.StringAttribute{
 			Optional:            true,
 			Description:         "The target's proxy target's ID (ID of a Linux, Windows, or Kubernetes target).",
-			MarkdownDescription: "The target's proxy target's ID (ID of a [Linux](bzero_target), [Windows](bzero_target), or [Kubernetes](cluster_target) target).",
+			MarkdownDescription: "The target's proxy target's ID (ID of a [Linux](../data-sources/bzero_target), [Windows](../data-sources/bzero_target), or [Kubernetes](../data-sources/cluster_target) target).",
 			Validators: []validator.String{
 				bzvalidator.ValidUUIDV4(),
 			},

--- a/bastionzero/target/dbtarget/resource_dbtarget.go
+++ b/bastionzero/target/dbtarget/resource_dbtarget.go
@@ -65,7 +65,7 @@ func (r *dbTargetResource) Metadata(_ context.Context, req resource.MetadataRequ
 // Schema defines the schema for the db target resource.
 func (r *dbTargetResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Provides a BastionZero database target. Database targets configure remote access to database servers running on [Linux](bzero_target), [Windows](bzero_target), or [Kubernetes](cluster_target) targets.",
+		MarkdownDescription: "Provides a BastionZero database target. Database targets configure remote access to database servers running on [Linux](../data-sources/bzero_target), [Windows](../data-sources/bzero_target), or [Kubernetes](../data-sources/cluster_target) targets.",
 		Attributes:          makeDbTargetResourceSchema(ctx),
 	}
 }

--- a/docs/resources/db_target.md
+++ b/docs/resources/db_target.md
@@ -2,12 +2,12 @@
 page_title: "bastionzero_db_target Resource - terraform-provider-bastionzero"
 subcategory: "Target"
 description: |-
-  Provides a BastionZero database target. Database targets configure remote access to database servers running on Linux bzero_target, Windows bzero_target, or Kubernetes cluster_target targets.
+  Provides a BastionZero database target. Database targets configure remote access to database servers running on Linux ../data-sources/bzero_target, Windows ../data-sources/bzero_target, or Kubernetes ../data-sources/cluster_target targets.
 ---
 
 # bastionzero_db_target (Resource)
 
-Provides a BastionZero database target. Database targets configure remote access to database servers running on [Linux](bzero_target), [Windows](bzero_target), or [Kubernetes](cluster_target) targets.
+Provides a BastionZero database target. Database targets configure remote access to database servers running on [Linux](../data-sources/bzero_target), [Windows](../data-sources/bzero_target), or [Kubernetes](../data-sources/cluster_target) targets.
 
 Learn more about Db targets [here](https://docs.bastionzero.com/docs/deployment/installing-the-agent#databases).
 
@@ -30,8 +30,8 @@ configuration is used.
 -> **Note** If you don't know what combination of values to use for
 [`database_authentication_config`](#database_authentication_config), then you
 can use the
-[`bastionzero_supported_database_configs`](supported_database_configs) data
-source to get a list of supported values.
+[`bastionzero_supported_database_configs`](../data-sources/supported_database_configs)
+data source to get a list of supported values.
 
 ~> **Warning** _Modifying_ a Db target's
 [`database_authentication_config.authentication_type`](#authentication_type)
@@ -232,7 +232,7 @@ resource "bastionzero_db_target" "example" {
 - `database_authentication_config` (Attributes) Information about the db target's database authentication configuration. If this attribute is left unconfigured, the target is configured with the default, non-passwordless database configuration. (see [below for nested schema](#nestedatt--database_authentication_config))
 - `local_port` (Number) The port of the Db daemon's localhost server that is spawned on the user's machine on connect. If this attribute is left unconfigured, an available port will be chosen when the target is connected to.
 - `proxy_environment_id` (String) The target's proxy environment's ID (ID of the backing proxy environment).
-- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Linux](bzero_target), [Windows](bzero_target), or [Kubernetes](cluster_target) target).
+- `proxy_target_id` (String) The target's proxy target's ID (ID of a [Linux](../data-sources/bzero_target), [Windows](../data-sources/bzero_target), or [Kubernetes](../data-sources/cluster_target) target).
 
 ### Read-Only
 

--- a/templates/resources/db_target.md.tmpl
+++ b/templates/resources/db_target.md.tmpl
@@ -30,8 +30,8 @@ configuration is used.
 -> **Note** If you don't know what combination of values to use for
 [`database_authentication_config`](#database_authentication_config), then you
 can use the
-[`bastionzero_supported_database_configs`](supported_database_configs) data
-source to get a list of supported values.
+[`bastionzero_supported_database_configs`](../data-sources/supported_database_configs)
+data source to get a list of supported values.
 
 ~> **Warning** _Modifying_ a Db target's
 [`database_authentication_config.authentication_type`](#authentication_type)


### PR DESCRIPTION
Must go up a level to reference data sources from a resource doc

Why I think this will fix it?

- Checkout this link: https://github.com/bastionzero/terraform-provider-bastionzero/blob/fix/db-docs/docs/data-sources/bzero_targets.md and click `bastionzero_bzero_target` link. Then add `.md` to the url. That link works right now on the live docs page
- Now checkout this link: https://github.com/bastionzero/terraform-provider-bastionzero/blob/fix/db-docs/docs/resources/db_target.md and click on the `Linux` link. Then add `.md` to the url. That link works. Hopefully the logic is the same there